### PR TITLE
feat: add multi-user support, Home Assistant mapping plus read-only HKC v3 panel helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Python module for interacting with HKC's Alarm API, allowing for easy interactio
 - Fetch all inputs.
 - View recent logs.
 - Arm and disarm the alarm in various modes.
+- Configure multiple user codes for the same panel and inspect per-user access.
 
 ## Installation
 
@@ -36,7 +37,7 @@ pip install -r requirements.txt
 ## Example Usage
 
 ```python
-from hkc_alarm import HKCAlarm
+from pyhkc import HKCAlarm
 
 # Initialize the system with your credentials.
 panel_id = [your-panel-id]  # replace with your panel ID
@@ -62,6 +63,34 @@ print("Recent Logs:", logs)
 
 # Disarm the system.
 # alarm_system.disarm()
+```
+
+Single-user initialization remains unchanged. If you have multiple panel users with different permissions, add their codes with `user_codes` and query their effective access separately:
+
+```python
+from pyhkc import HKCAlarm
+
+alarm_system = HKCAlarm(
+    panel_id,
+    panel_password,
+    1111,  # default / active user code
+    user_codes=[2222],
+)
+
+# Use the original methods with the active user code.
+status = alarm_system.get_system_status()
+
+# Or inspect every configured user and their access levels.
+access_summary = alarm_system.get_user_access_summary()
+print(access_summary[1111]["allowedBlocks"])
+print(access_summary[2222]["allowedBlocks"])
+
+# Temporarily act as another configured user.
+alarm_system.set_active_user(2222)
+guest_status = alarm_system.get_system_status()
+
+# You can also override the user per call without switching the active user.
+admin_status = alarm_system.get_system_status(user_code=1111)
 ```
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ access_summary = alarm_system.get_user_access_summary()
 print(access_summary[1111]["allowedBlocks"])
 print(access_summary[2222]["allowedBlocks"])
 
+# Build a Home Assistant-oriented block/entity mapping.
+entity_map = alarm_system.get_home_assistant_entity_map()
+for block in entity_map["blocks"]:
+    print(block["description"], block["accessUserCodes"], len(block["inputs"]))
+
 # Temporarily act as another configured user.
 alarm_system.set_active_user(2222)
 guest_status = alarm_system.get_system_status()
@@ -92,6 +97,12 @@ guest_status = alarm_system.get_system_status()
 # You can also override the user per call without switching the active user.
 admin_status = alarm_system.get_system_status(user_code=1111)
 ```
+
+`get_home_assistant_entity_map()` is conservative:
+
+- it assigns an input to a block only when the set of users who can see that input matches exactly one block's `accessUserCodes`
+- it leaves inputs in `sharedInputs` when every configured user can see them
+- it leaves inputs in `ambiguousInputs` when the upstream API does not provide enough information to place them safely on one block
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Python module for interacting with HKC's Alarm API, allowing for easy interactio
 
 - Retrieve system status.
 - Fetch all inputs.
+- Inspect read-only panel details, outputs, and temporary-user status.
 - View recent logs.
 - Arm and disarm the alarm in various modes.
 - Configure multiple user codes for the same panel and inspect per-user access.
@@ -85,6 +86,11 @@ access_summary = alarm_system.get_user_access_summary()
 print(access_summary[1111]["allowedBlocks"])
 print(access_summary[2222]["allowedBlocks"])
 
+# Read-only v3 helpers confirmed against the current app/API.
+details = alarm_system.get_device_details()
+outputs = alarm_system.get_outputs()
+temporary_user = alarm_system.get_temporary_user()
+
 # Build a Home Assistant-oriented block/entity mapping.
 entity_map = alarm_system.get_home_assistant_entity_map()
 for block in entity_map["blocks"]:
@@ -103,6 +109,12 @@ admin_status = alarm_system.get_system_status(user_code=1111)
 - it assigns an input to a block only when the set of users who can see that input matches exactly one block's `accessUserCodes`
 - it leaves inputs in `sharedInputs` when every configured user can see them
 - it leaves inputs in `ambiguousInputs` when the upstream API does not provide enough information to place them safely on one block
+
+The additional read-only helpers are intended for diagnostics and integrations:
+
+- `get_device_details()` returns panel metadata such as variant, platform, installation name, and site name when the upstream API exposes them
+- `get_outputs()` returns the current device outputs payload, which may be empty on some panels
+- `get_temporary_user()` returns the current temporary-user status for the authenticated panel user
 
 ## Publishing
 

--- a/pyhkc/hkc_api.py
+++ b/pyhkc/hkc_api.py
@@ -336,13 +336,21 @@ class HKCAlarm:
 
   def get_panel(self):
       # remote keypad
-      data = {
-          "hardwareId": self.hardware_id,
-          "deviceId": self.device_id,
-          "devicePassword": self.panel_password,
-          "keys": ""
-      }
+      data = self._device_request_payload()
+      data["keys"] = ""
       return self._api_request("POST", f"{self.base_url}/AppV3/Device/RemoteKeypad", data)
+
+  def get_device_details(self, user_code=None):
+    data = self._device_request_payload(user_code=user_code)
+    return self._api_request("POST", f"{self.base_url}/AppV3/Device/Details", data)
+
+  def get_outputs(self, user_code=None):
+    data = self._device_request_payload(user_code=user_code)
+    return self._api_request("POST", f"{self.base_url}/AppV3/Device/Outputs", data)
+
+  def get_temporary_user(self, user_code=None):
+    data = self._device_request_payload(user_code=user_code)
+    return self._api_request("POST", f"{self.base_url}/AppV3/Device/GetTemporaryUser", data)
 
   # Private methods for direct API calls
 
@@ -364,41 +372,36 @@ class HKCAlarm:
   def _get_status(self, data):
     return self._api_request("POST", f"{self.base_url}/AppV3/Device/Status", data)
 
-  def _arm_or_disarm(self, command, block, user_code=None):
+  def _device_request_payload(self, user_code=None):
     resolved_user_code = self._resolve_user_code(user_code)
-    data = {
+    return {
       "hardwareId": self.hardware_id,
       "deviceId": self.device_id,
       "devicePassword": self.panel_password,
       "userCode": str(resolved_user_code),
+    }
+
+  def _arm_or_disarm(self, command, block, user_code=None):
+    data = self._device_request_payload(user_code=user_code)
+    data.update({
       "command": command,
       "block": block,
-      "inhibit": False
-    }
+      "inhibit": False,
+    })
     return self._api_request("POST", f"{self.base_url}/AppV3/Device/Arming", data)
 
   def _get_logs(self, data):
     # appv3 format  
     event_id = data.get("panelEventId")
-    request_data = {
-      "hardwareId": self.hardware_id,
-      "deviceId": self.device_id,
-      "devicePassword": self.panel_password,
-      "eventId": event_id
-    }
+    request_data = self._device_request_payload()
+    request_data["eventId"] = event_id
     return self._api_request("POST", f"{self.base_url}/AppV3/Device/Logs", request_data)
 
   def _get_inputs(self, data):
     first_input = data.get("firstInput", 1)
-    user_code = self._resolve_user_code(data.get("userCode"))
-    data = {
-      "hardwareId": self.hardware_id,
-      "deviceId": self.device_id,
-      "devicePassword": self.panel_password,
-      "userCode": str(user_code),
-      "firstInput": first_input
-    }
-    return self._api_request("POST", f"{self.base_url}/AppV3/Device/Inputs", data)
+    request_data = self._device_request_payload(user_code=data.get("userCode"))
+    request_data["firstInput"] = first_input
+    return self._api_request("POST", f"{self.base_url}/AppV3/Device/Inputs", request_data)
 
   def _get_device_id(self, user_code=None):
     # must call first for appv3
@@ -414,11 +417,7 @@ class HKCAlarm:
   
   def _get_latest_event_id(self):
     # get latest event id for logs
-    data = {
-      "hardwareId": self.hardware_id,
-      "deviceId": self.device_id,
-      "devicePassword": self.panel_password
-    }
+    data = self._device_request_payload()
     response = self._api_request("POST", f"{self.base_url}/AppV3/Device/Log", data)
     return response.get("eventId")
 

--- a/pyhkc/hkc_api.py
+++ b/pyhkc/hkc_api.py
@@ -1,16 +1,19 @@
-import requests
+import logging
 import os
 import uuid
+from typing import Iterable
+
+import requests
 from tabulate import tabulate
-import logging
-from tenacity import retry, wait_exponential, stop_after_attempt
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 class HKCAlarm:
-  def __init__(self, panel_id, panel_password, user_code, base_url="https://hkc.api.securecomm.cloud", log_level=logging.INFO):
+  def __init__(self, panel_id, panel_password, user_code, base_url="https://hkc.api.securecomm.cloud", log_level=logging.INFO, user_codes=None):
     self.base_url = base_url
     self.panel_id = int(panel_id)
     self.panel_password = panel_password
-    self.user_code = int(user_code)
+    self.user_codes = self._normalize_user_codes(user_code, user_codes)
+    self.user_code = self.user_codes[0]
     self.headers = {
       "Host": "hkc.api.securecomm.cloud",
       "accept": "application/json, text/plain, */*",
@@ -27,11 +30,68 @@ class HKCAlarm:
     self.logger.info("Initializing HKCAlarm")
     self._initialize()
 
+  @staticmethod
+  def _coerce_user_code(user_code):
+    return int(user_code)
+
+  @classmethod
+  def _normalize_user_codes(cls, primary_user_code, user_codes=None):
+    normalized_codes = []
+
+    def add_code(candidate):
+      code = cls._coerce_user_code(candidate)
+      if code not in normalized_codes:
+        normalized_codes.append(code)
+
+    add_code(primary_user_code)
+
+    if user_codes is None:
+      return normalized_codes
+
+    if isinstance(user_codes, Iterable) and not isinstance(user_codes, (str, bytes)):
+      for candidate in user_codes:
+        add_code(candidate)
+      return normalized_codes
+
+    add_code(user_codes)
+    return normalized_codes
+
+  def _resolve_user_code(self, user_code=None):
+    if user_code is None:
+      return self.user_code
+    return self._coerce_user_code(user_code)
+
+  @classmethod
+  def _normalize_requested_user_codes(cls, user_codes):
+    if isinstance(user_codes, Iterable) and not isinstance(user_codes, (str, bytes)):
+      return list(dict.fromkeys(cls._coerce_user_code(candidate) for candidate in user_codes))
+    return [cls._coerce_user_code(user_codes)]
+
+  @staticmethod
+  def _block_description(descriptions, block_number):
+    return descriptions.get(f"block{block_number}", f"Block {block_number}")
+
   def _initialize(self):
     # get device id first - required for appv3
     self.device_id = self._get_device_id()
     self.logger.info(f"Obtained device ID: {self.device_id}")
     self.securecomm_address = self.get_system_status().get('secureCommAddress', self.securecomm_address)
+
+  def list_user_codes(self):
+    return list(self.user_codes)
+
+  def add_user(self, user_code):
+    normalized_code = self._coerce_user_code(user_code)
+    if normalized_code not in self.user_codes:
+      self.user_codes.append(normalized_code)
+    return normalized_code
+
+  def set_active_user(self, user_code):
+    normalized_code = self._coerce_user_code(user_code)
+    if normalized_code not in self.user_codes:
+      raise ValueError(f"User code {normalized_code} is not configured on this client")
+    self.user_code = normalized_code
+    return self.user_code
 
   def register_mobile(self, app_version="1.0.2", hardware_id="", description=""):
     data = {
@@ -44,28 +104,64 @@ class HKCAlarm:
     }
     return self._mobile_register(data)
 
-  def get_system_status(self):
+  def get_system_status(self, user_code=None):
+    resolved_user_code = self._resolve_user_code(user_code)
     data = {
       "hardwareId": self.hardware_id,
       "deviceId": self.device_id,
       "devicePassword": self.panel_password,
-      "userCode": str(self.user_code),
+      "userCode": str(resolved_user_code),
       "includeDescriptions": True
     }
     response = self._get_status(data)
+    self.securecomm_address = response.get('secureCommAddress', self.securecomm_address)
     return response
 
-  def arm_partset_a(self):
-    return self._arm_or_disarm(command=1, block=0)
+  def get_users_status(self, user_codes=None):
+    target_user_codes = self._normalize_requested_user_codes(user_codes) if user_codes is not None else self.list_user_codes()
+    return {code: self.get_system_status(user_code=code) for code in target_user_codes}
 
-  def arm_partset_b(self):
-    return self._arm_or_disarm(command=2, block=0)
+  def get_user_access_summary(self, user_codes=None):
+    summaries = {}
+    for code, status in self.get_users_status(user_codes=user_codes).items():
+      descriptions = status.get("descriptions", {})
+      allowed_blocks = []
+      denied_blocks = []
 
-  def arm_fullset(self):
-    return self._arm_or_disarm(command=3, block=0)
+      for block_number, block in enumerate(status.get("blocks", []), start=1):
+        if not block.get("isEnabled"):
+          continue
 
-  def disarm(self):
-    return self._arm_or_disarm(command=0, block=0)
+        block_summary = {
+          "block": block_number,
+          "description": self._block_description(descriptions, block_number),
+          "armState": block.get("armState"),
+        }
+
+        if block.get("userAllowed"):
+          allowed_blocks.append(block_summary)
+        else:
+          denied_blocks.append(block_summary)
+
+      summaries[code] = {
+        "userOptions": status.get("userOptions", {}),
+        "allowedBlocks": allowed_blocks,
+        "deniedBlocks": denied_blocks,
+      }
+
+    return summaries
+
+  def arm_partset_a(self, user_code=None):
+    return self._arm_or_disarm(command=1, block=0, user_code=user_code)
+
+  def arm_partset_b(self, user_code=None):
+    return self._arm_or_disarm(command=2, block=0, user_code=user_code)
+
+  def arm_fullset(self, user_code=None):
+    return self._arm_or_disarm(command=3, block=0, user_code=user_code)
+
+  def disarm(self, user_code=None):
+    return self._arm_or_disarm(command=0, block=0, user_code=user_code)
 
   def fetch_logs(self, num_previous_logs=10):
     latest_event_id = self._get_latest_event_id()
@@ -85,7 +181,8 @@ class HKCAlarm:
         latest_event_id = start_event_id - 1  # Decrement for the next batch
     return logs[:num_previous_logs]  # Return only the desired number of logs
 
-  def get_all_inputs(self):
+  def get_all_inputs(self, user_code=None):
+    resolved_user_code = self._resolve_user_code(user_code)
     all_inputs = []
     more_inputs = True
     first_input = 1
@@ -94,7 +191,7 @@ class HKCAlarm:
       data = {
         "panelId": self.panel_id,
         "panelPassword": self.panel_password,
-        "userCode": self.user_code,
+        "userCode": resolved_user_code,
         "firstInput": first_input,
         "secureCommAddress": self.securecomm_address
       }
@@ -110,8 +207,8 @@ class HKCAlarm:
 
     return all_inputs
 
-  def check_login(self):
-      system_status = self.get_system_status()
+  def check_login(self, user_code=None):
+      system_status = self.get_system_status(user_code=user_code)
       # Check for a successful login
       if 'userOptions' in system_status:
           return True
@@ -153,12 +250,13 @@ class HKCAlarm:
   def _get_status(self, data):
     return self._api_request("POST", f"{self.base_url}/AppV3/Device/Status", data)
 
-  def _arm_or_disarm(self, command, block):
+  def _arm_or_disarm(self, command, block, user_code=None):
+    resolved_user_code = self._resolve_user_code(user_code)
     data = {
       "hardwareId": self.hardware_id,
       "deviceId": self.device_id,
       "devicePassword": self.panel_password,
-      "userCode": str(self.user_code),
+      "userCode": str(resolved_user_code),
       "command": command,
       "block": block,
       "inhibit": False
@@ -178,22 +276,24 @@ class HKCAlarm:
 
   def _get_inputs(self, data):
     first_input = data.get("firstInput", 1)
+    user_code = self._resolve_user_code(data.get("userCode"))
     data = {
       "hardwareId": self.hardware_id,
       "deviceId": self.device_id,
       "devicePassword": self.panel_password,
-      "userCode": str(self.user_code),
+      "userCode": str(user_code),
       "firstInput": first_input
     }
     return self._api_request("POST", f"{self.base_url}/AppV3/Device/Inputs", data)
 
-  def _get_device_id(self):
+  def _get_device_id(self, user_code=None):
     # must call first for appv3
+    resolved_user_code = self._resolve_user_code(user_code)
     data = {
       "hardwareId": self.hardware_id,
       "installationId": self.panel_id,
       "devicePassword": self.panel_password,
-      "userCode": str(self.user_code)
+      "userCode": str(resolved_user_code)
     }
     response = self._api_request("POST", f"{self.base_url}/AppV3/App/GetDeviceId", data)
     return response.get("deviceId")

--- a/pyhkc/hkc_api.py
+++ b/pyhkc/hkc_api.py
@@ -71,6 +71,40 @@ class HKCAlarm:
   def _block_description(descriptions, block_number):
     return descriptions.get(f"block{block_number}", f"Block {block_number}")
 
+  @staticmethod
+  def _input_key(input_data):
+    return input_data.get("inputId", input_data.get("input"))
+
+  def _build_block_access_map(self, statuses):
+    blocks = {}
+
+    for code, status in statuses.items():
+      descriptions = status.get("descriptions", {})
+      for block_number, block in enumerate(status.get("blocks", []), start=1):
+        if not block.get("isEnabled"):
+          continue
+
+        existing = blocks.setdefault(block_number, {
+          "block": block_number,
+          "description": self._block_description(descriptions, block_number),
+          "isEnabled": True,
+          "armState": block.get("armState"),
+          "accessUserCodes": [],
+        })
+
+        if block.get("userAllowed") and code not in existing["accessUserCodes"]:
+          existing["accessUserCodes"].append(code)
+
+    return {
+      "blocks": [
+        {
+          **block,
+          "accessUserCodes": sorted(block["accessUserCodes"]),
+        }
+        for _, block in sorted(blocks.items())
+      ]
+    }
+
   def _initialize(self):
     # get device id first - required for appv3
     self.device_id = self._get_device_id()
@@ -121,6 +155,14 @@ class HKCAlarm:
     target_user_codes = self._normalize_requested_user_codes(user_codes) if user_codes is not None else self.list_user_codes()
     return {code: self.get_system_status(user_code=code) for code in target_user_codes}
 
+  def get_users_inputs(self, user_codes=None):
+    target_user_codes = self._normalize_requested_user_codes(user_codes) if user_codes is not None else self.list_user_codes()
+    return {code: self.get_all_inputs(user_code=code) for code in target_user_codes}
+
+  def get_block_access_map(self, user_codes=None):
+    statuses = self.get_users_status(user_codes=user_codes)
+    return self._build_block_access_map(statuses)
+
   def get_user_access_summary(self, user_codes=None):
     summaries = {}
     for code, status in self.get_users_status(user_codes=user_codes).items():
@@ -150,6 +192,78 @@ class HKCAlarm:
       }
 
     return summaries
+
+  def get_home_assistant_entity_map(self, user_codes=None):
+    statuses = self.get_users_status(user_codes=user_codes)
+    inputs_by_user = self.get_users_inputs(user_codes=statuses.keys())
+    block_map = self._build_block_access_map(statuses)
+    configured_user_codes = list(statuses.keys())
+    configured_user_set = frozenset(configured_user_codes)
+
+    block_visibility_signatures = {}
+    for block in block_map["blocks"]:
+      signature = frozenset(block["accessUserCodes"])
+      block_visibility_signatures.setdefault(signature, []).append(block["block"])
+
+    user_input_index = {}
+    merged_inputs = {}
+    input_visible_to = {}
+    for code, inputs in inputs_by_user.items():
+      indexed_inputs = {}
+      for input_data in inputs:
+        input_key = self._input_key(input_data)
+        indexed_inputs[input_key] = input_data
+        merged_inputs.setdefault(input_key, input_data)
+        input_visible_to.setdefault(input_key, set()).add(code)
+      user_input_index[code] = indexed_inputs
+
+    block_inputs = {block["block"]: [] for block in block_map["blocks"]}
+    shared_inputs = []
+    ambiguous_inputs = []
+
+    for input_key, input_data in sorted(merged_inputs.items(), key=lambda item: item[0]):
+      visible_user_codes = sorted(input_visible_to.get(input_key, set()))
+      visibility_signature = frozenset(visible_user_codes)
+      candidate_blocks = block_visibility_signatures.get(visibility_signature, [])
+      annotated_input = dict(input_data)
+      annotated_input["visibleUserCodes"] = visible_user_codes
+
+      if len(candidate_blocks) == 1:
+        block_inputs[candidate_blocks[0]].append(annotated_input)
+      elif len(candidate_blocks) > 1:
+        ambiguous_input = dict(annotated_input)
+        ambiguous_input["candidateBlocks"] = candidate_blocks
+        ambiguous_inputs.append(ambiguous_input)
+      elif visibility_signature == configured_user_set:
+        shared_inputs.append(annotated_input)
+      else:
+        ambiguous_input = dict(annotated_input)
+        ambiguous_input["candidateBlocks"] = candidate_blocks
+        ambiguous_inputs.append(ambiguous_input)
+
+    for block in block_map["blocks"]:
+      block["inputs"] = block_inputs[block["block"]]
+
+    return {
+      "panel": {
+        "panelId": self.panel_id,
+        "deviceId": self.device_id,
+      },
+      "users": {
+        code: {
+          "allowedBlocks": [
+            block["block"]
+            for block in block_map["blocks"]
+            if code in block["accessUserCodes"]
+          ],
+          "visibleInputs": sorted(user_input_index[code].keys()),
+        }
+        for code in configured_user_codes
+      },
+      "blocks": block_map["blocks"],
+      "sharedInputs": shared_inputs,
+      "ambiguousInputs": ambiguous_inputs,
+    }
 
   def arm_partset_a(self, user_code=None):
     return self._arm_or_disarm(command=1, block=0, user_code=user_code)

--- a/tests/test_hkc_api.py
+++ b/tests/test_hkc_api.py
@@ -61,6 +61,76 @@ class HKCAlarmTests(unittest.TestCase):
     self.assertEqual(first_payload["userCode"], "2222")
     self.assertEqual(second_payload["userCode"], "1111")
 
+  def test_home_assistant_entity_map_assigns_unique_and_shared_inputs(self):
+    with patch.object(HKCAlarm, "_initialize", fake_initialize):
+      alarm = HKCAlarm(123456, "panel-password", 1111, user_codes=[2222])
+
+    statuses = {
+      1111: {
+        "descriptions": {"block1": "Main House", "block2": "House 2"},
+        "blocks": [
+          {"isEnabled": True, "userAllowed": True, "armState": 0},
+          {"isEnabled": True, "userAllowed": False, "armState": 0},
+        ],
+      },
+      2222: {
+        "descriptions": {"block1": "Main House", "block2": "House 2"},
+        "blocks": [
+          {"isEnabled": True, "userAllowed": False, "armState": 0},
+          {"isEnabled": True, "userAllowed": True, "armState": 0},
+        ],
+      },
+    }
+    inputs = {
+      1111: [
+        {"input": 1, "inputId": 1, "description": "Main Sensor"},
+        {"input": 3, "inputId": 3, "description": "Shared Sensor"},
+      ],
+      2222: [
+        {"input": 2, "inputId": 2, "description": "House 2 Sensor"},
+        {"input": 3, "inputId": 3, "description": "Shared Sensor"},
+      ],
+    }
+
+    with patch.object(alarm, "get_users_status", return_value=statuses), patch.object(alarm, "get_users_inputs", return_value=inputs):
+      entity_map = alarm.get_home_assistant_entity_map()
+
+    blocks = {block["block"]: block for block in entity_map["blocks"]}
+    self.assertEqual(blocks[1]["accessUserCodes"], [1111])
+    self.assertEqual(blocks[2]["accessUserCodes"], [2222])
+    self.assertEqual([item["inputId"] for item in blocks[1]["inputs"]], [1])
+    self.assertEqual([item["inputId"] for item in blocks[2]["inputs"]], [2])
+    self.assertEqual([item["inputId"] for item in entity_map["sharedInputs"]], [3])
+    self.assertEqual(entity_map["ambiguousInputs"], [])
+
+  def test_home_assistant_entity_map_marks_inputs_ambiguous_for_multi_block_user(self):
+    with patch.object(HKCAlarm, "_initialize", fake_initialize):
+      alarm = HKCAlarm(123456, "panel-password", 1111)
+
+    statuses = {
+      1111: {
+        "descriptions": {"block1": "Main House", "block2": "House 2"},
+        "blocks": [
+          {"isEnabled": True, "userAllowed": True, "armState": 0},
+          {"isEnabled": True, "userAllowed": True, "armState": 0},
+        ],
+      },
+    }
+    inputs = {
+      1111: [
+        {"input": 7, "inputId": 7, "description": "Shared By Signature"},
+      ],
+    }
+
+    with patch.object(alarm, "get_users_status", return_value=statuses), patch.object(alarm, "get_users_inputs", return_value=inputs):
+      entity_map = alarm.get_home_assistant_entity_map()
+
+    self.assertEqual(entity_map["sharedInputs"], [])
+    self.assertEqual(entity_map["blocks"][0]["inputs"], [])
+    self.assertEqual(entity_map["blocks"][1]["inputs"], [])
+    self.assertEqual(entity_map["ambiguousInputs"][0]["candidateBlocks"], [1, 2])
+    self.assertEqual(entity_map["ambiguousInputs"][0]["inputId"], 7)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/test_hkc_api.py
+++ b/tests/test_hkc_api.py
@@ -61,6 +61,35 @@ class HKCAlarmTests(unittest.TestCase):
     self.assertEqual(first_payload["userCode"], "2222")
     self.assertEqual(second_payload["userCode"], "1111")
 
+  def test_read_only_device_helpers_use_v3_device_auth_payload(self):
+    with patch.object(HKCAlarm, "_initialize", fake_initialize):
+      alarm = HKCAlarm(123456, "panel-password", 1111, user_codes=[2222])
+
+    with patch.object(alarm, "_api_request", side_effect=[{"variant": "SW-10270"}, [], {"subscriptionDaysLeft": 0}]) as mock_api_request:
+      details = alarm.get_device_details()
+      outputs = alarm.get_outputs(user_code=2222)
+      temporary_user = alarm.get_temporary_user()
+
+    self.assertEqual(details["variant"], "SW-10270")
+    self.assertEqual(outputs, [])
+    self.assertEqual(temporary_user["subscriptionDaysLeft"], 0)
+
+    details_call = mock_api_request.call_args_list[0].args
+    outputs_call = mock_api_request.call_args_list[1].args
+    temporary_user_call = mock_api_request.call_args_list[2].args
+
+    self.assertEqual(details_call[1], "https://hkc.api.securecomm.cloud/AppV3/Device/Details")
+    self.assertEqual(details_call[2]["hardwareId"], alarm.hardware_id)
+    self.assertEqual(details_call[2]["deviceId"], "device-id")
+    self.assertEqual(details_call[2]["devicePassword"], "panel-password")
+    self.assertEqual(details_call[2]["userCode"], "1111")
+
+    self.assertEqual(outputs_call[1], "https://hkc.api.securecomm.cloud/AppV3/Device/Outputs")
+    self.assertEqual(outputs_call[2]["userCode"], "2222")
+
+    self.assertEqual(temporary_user_call[1], "https://hkc.api.securecomm.cloud/AppV3/Device/GetTemporaryUser")
+    self.assertEqual(temporary_user_call[2]["userCode"], "1111")
+
   def test_home_assistant_entity_map_assigns_unique_and_shared_inputs(self):
     with patch.object(HKCAlarm, "_initialize", fake_initialize):
       alarm = HKCAlarm(123456, "panel-password", 1111, user_codes=[2222])

--- a/tests/test_hkc_api.py
+++ b/tests/test_hkc_api.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch
+
+from pyhkc import HKCAlarm
+
+
+def fake_initialize(self):
+  self.device_id = "device-id"
+  self.securecomm_address = "securecomm-address"
+
+
+class HKCAlarmTests(unittest.TestCase):
+  def test_single_user_status_uses_default_user_code(self):
+    with patch.object(HKCAlarm, "_initialize", fake_initialize):
+      alarm = HKCAlarm(123456, "panel-password", 1111)
+
+    with patch.object(alarm, "_get_status", return_value={"userOptions": {"unset": True}}) as mock_get_status:
+      status = alarm.get_system_status()
+
+    self.assertEqual(status["userOptions"]["unset"], True)
+    self.assertEqual(mock_get_status.call_args.args[0]["userCode"], "1111")
+    self.assertEqual(alarm.list_user_codes(), [1111])
+
+  def test_multi_user_summary_reports_per_user_block_access(self):
+    with patch.object(HKCAlarm, "_initialize", fake_initialize):
+      alarm = HKCAlarm(123456, "panel-password", 1111, user_codes=[2222])
+
+    def status_for_user(payload):
+      user_code = payload["userCode"]
+      return {
+        "userOptions": {"fullset": user_code == "1111"},
+        "descriptions": {"block1": "Main House", "block2": "Guest Suite"},
+        "blocks": [
+          {"isEnabled": True, "userAllowed": user_code == "1111", "armState": 0},
+          {"isEnabled": True, "userAllowed": user_code == "2222", "armState": 0},
+        ],
+      }
+
+    with patch.object(alarm, "_get_status", side_effect=status_for_user):
+      summary = alarm.get_user_access_summary()
+
+    self.assertEqual(alarm.list_user_codes(), [1111, 2222])
+    self.assertEqual(summary[1111]["allowedBlocks"][0]["description"], "Main House")
+    self.assertEqual(summary[1111]["deniedBlocks"][0]["description"], "Guest Suite")
+    self.assertEqual(summary[2222]["allowedBlocks"][0]["description"], "Guest Suite")
+    self.assertEqual(summary[2222]["userOptions"]["fullset"], False)
+
+  def test_active_user_switch_and_explicit_override_are_supported(self):
+    with patch.object(HKCAlarm, "_initialize", fake_initialize):
+      alarm = HKCAlarm(123456, "panel-password", 1111, user_codes=[2222])
+
+    alarm.set_active_user(2222)
+
+    with patch.object(alarm, "_api_request", return_value={"success": True}) as mock_api_request:
+      alarm.arm_fullset()
+      alarm.disarm(user_code=1111)
+
+    first_payload = mock_api_request.call_args_list[0].args[2]
+    second_payload = mock_api_request.call_args_list[1].args[2]
+
+    self.assertEqual(first_payload["userCode"], "2222")
+    self.assertEqual(second_payload["userCode"], "1111")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

Extend `pyhkc` with additive multi-user and Home Assistant mapping support, and expose confirmed read-only HKC v3 helpers for panel diagnostics.

## Changes

- preserve existing single-user initialization and behavior
- add additive multi-user support via `user_codes`
- add per-user access inspection with `get_users_status()`, `get_users_inputs()`, and `get_user_access_summary()`
- add `get_block_access_map()` and `get_home_assistant_entity_map()` for Home Assistant-oriented block/entity mapping
- keep block/input assignment conservative:
  - assign an input to a block only when the visible-user signature matches exactly one block
  - leave globally visible inputs in `sharedInputs`
  - leave unclear inputs in `ambiguousInputs`
- add confirmed read-only HKC v3 helpers:
  - `get_device_details()`
  - `get_outputs()`
  - `get_temporary_user()`
- refactor duplicated device-auth request payload construction into a shared internal helper
- document the new helpers and mapping behavior in the README
- add unit tests covering:
  - single-user compatibility
  - active-user switching and per-call overrides
  - per-user block access summaries
  - Home Assistant entity-map assignment rules
  - read-only device helper request payloads

## Verification

- ran `./.venv/bin/python -m unittest discover -s tests -v`
- ran live read-only smoke tests against a real panel for:
  - `Status`
  - `Inputs`
  - `Details`
  - `Outputs`
  - `GetTemporaryUser`
- no arm/disarm, inhibit, or output-control commands were sent

## Current Upstream Limitation

HKC currently exposes verified per-user block access, but I could not verify a reliable upstream input-to-block mapping for this panel.

On the verified panel:
- block access differs by user
- the `Inputs` payload is identical across the tested users
- `get_home_assistant_entity_map()` therefore places all inputs in `sharedInputs` and leaves `blocks[*].inputs` empty

This means Home Assistant can safely model block access, but cannot yet attach sensors to specific blocks unless a richer upstream endpoint is found or a manual mapping layer is introduced.

## Attribution

These changes were AI-generated and then reviewed and verified by me before use.
